### PR TITLE
Response with all items as an object with keys instead of array

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -10,8 +10,7 @@ router.get('/all', function (req, res) {
 router.get('/', (req, res) => {
     Item.find({status: {$ne: 'deleted'}})
         .then((items) => {
-            console.log(items);
-            res.status(200).json(items);
+            res.status(200).json(Object.assign({}, items));
         })
         .catch((err) => {
             res.status(500).json({err: err});


### PR DESCRIPTION
Instead of responding to the get call '/' with an array of objects, respond with an object